### PR TITLE
RFC4648 compliant base64 encoder/decoder

### DIFF
--- a/src/views/encoders-decoders/Base64.vue
+++ b/src/views/encoders-decoders/Base64.vue
@@ -14,13 +14,13 @@ onErrorCaptured(() => {
 function encode(v: string) {
   showErrorRef.value = false;
   inputRef.value = v;
-  outputRef.value = btoa(v);
+  outputRef.value = btoa(unescape(encodeURIComponent(v)));
 }
 
 function decode(v: string) {
   showErrorRef.value = false;
   outputRef.value = v;
-  inputRef.value = atob(v);
+  inputRef.value = decodeURIComponent(escape(atob(v)));
 }
 </script>
 


### PR DESCRIPTION
This PR makes the base64 encoder/decoder [RFC4648](https://tools.ietf.org/html/rfc4648#section-4) compliant which can handle UTF-8 correctly. 